### PR TITLE
Prevent ViewHost from corrupting SiteTree_Live table

### DIFF
--- a/code/ViewHost.php
+++ b/code/ViewHost.php
@@ -318,7 +318,14 @@ class ViewHost extends DataExtension {
       if (!$this->owner->ViewCollection()->ID) {
          $vcID = $this->owner->ViewCollection()->write();
          $this->owner->ViewCollectionID = $vcID;
+
+         // If the current_stage is Live, the record isn't published, and we run write(),
+         // Silverstripe will INSERT a bad row into SiteTree_Live. Therefore, we insure we're
+         // writing to the unpublished stage.
+         $stage = Versioned::current_stage();
+         Versioned::reading_stage('Stage');
          $this->owner->write();
+         Versioned::reading_stage($stage);
       }
       $config = GridFieldConfig_RecordEditor::create($itemsPerPage = 20);
       $viewsGrid = new GridField(


### PR DESCRIPTION
When ViewHost::updateCMSFields() runs the current_stage is normally Live. When
the SiteTree object it was associated with was unpublished, obviously no row
would exist for it in SiteTree_Live. However, because write() saw the Live mode
was active, it would only work with the SiteTree_Live table. This would cause it
to insert an incomplete an invalid row into SiteTree_Live, instead of just
updating the row in SiteTree like we wanted.

This fixes the issue by making sure that if the record isn't published, we
switch to Stage mode before running write.
