### PR TITLE
By default, base the pagination param for a View off of it's name

### DIFF
--- a/code/View.php
+++ b/code/View.php
@@ -65,7 +65,7 @@ class View extends DataObject {
    // these are transient - set by the template when using the view
    private $owner;
    private $resultsPerPage = 0;
-   private $paginationURLParam = 'start';
+   private $paginationURLParam;
 
 
    /**
@@ -156,7 +156,7 @@ class View extends DataObject {
       if (!$request)
          return $offset;
 
-      $startParam = $request->getVar($this->paginationURLParam);
+      $startParam = $request->getVar($this->URLParam());
       if(!$startParam)
          return $offset;
 
@@ -252,7 +252,7 @@ class View extends DataObject {
          $results = new PaginatedList($results, $request);
       }
 
-      $results->setPaginationGetVar($this->paginationURLParam);
+      $results->setPaginationGetVar($this->URLParam());
       $results->setPageLength($limit);
       $results->setPageStart($offset);
       $results->setTotalItems($totalItems);
@@ -316,5 +316,13 @@ class View extends DataObject {
 
    public function Summary() {
       return "{$this->Name} [{$this->getPage()->Title}]";
+   }
+
+
+   /**
+    * Get the Pagination URL Param
+    */
+   public function URLParam() {
+      return $this->paginationURLParam ?: strtolower($this->Name);
    }
 }

--- a/code/ViewHost.php
+++ b/code/ViewHost.php
@@ -111,11 +111,11 @@ class ViewHost extends DataExtension {
     *
     * @param string $name the name of the view to find
     * @param int $resultsPerPage (optional, default 0) - zero for unlimited results, otherwise how many to show per page
-    * @param string $paginationURLParam the query string key to use for pagination (default: start)
+    * @param string $paginationURLParam the query string key to use for pagination (defaults to ViewName)
     * @param boolean $traverse traverse hierarchy looking for view? (default: true)
     * @return View the found view or null if not found
     */
-   public function GetView($name, $resultsPerPage = 0, $paginationURLParam = 'start', $traverse = true) {
+   public function GetView($name, $resultsPerPage = 0, $paginationURLParam = null, $traverse = true) {
       $view = null;
 
       $callback = function($host, $view, &$allViews, $traversalLevel) use(&$name, $traverse) {
@@ -152,7 +152,7 @@ class ViewHost extends DataExtension {
     * @return View the found view or null if not found
     */
    public function HasView($name, $traverse = true) {
-      return ($this->GetView($name, $resultsPerPage = 0, $paginationURLParam = 'start', $traverse) != null);
+      return ($this->GetView($name, $resultsPerPage = 0, null, $traverse) != null);
    }
 
 
@@ -166,7 +166,7 @@ class ViewHost extends DataExtension {
     * @return View the found view or null if not found
     */
    public function HasViewWithResults($name, $traverse = true) {
-      $view = $this->GetView($name, $resultsPerPage = 0, $paginationURLParam = 'start', $traverse);
+      $view = $this->GetView($name, $resultsPerPage = 0, null, $traverse);
       if ($view == null) {
          return false;
       }


### PR DESCRIPTION
Instead of always defaulting to the same get param, base the default param off
of the View's name. This prevents conflicts amoung views using the same param on
the same page.
