### PR TITLE
Adjust GridField creation so Injector is used

### DIFF
--- a/code/ViewHost.php
+++ b/code/ViewHost.php
@@ -328,7 +328,7 @@ class ViewHost extends DataExtension {
          Versioned::reading_stage($stage);
       }
       $config = GridFieldConfig_RecordEditor::create($itemsPerPage = 20);
-      $viewsGrid = new GridField(
+      $viewsGrid = GridField::create(
          'Views',
          _t('Views.ViewsLabel', 'Views'),
          $this->owner->ViewCollection()->Views(),


### PR DESCRIPTION
Adjust how the GridField is created to allow for the Injector to provide a custom class for GridField. (e.g. https://github.com/silverstripe/silverstripe-framework/issues/3357#issuecomment-118266992)
