### PR TITLE
Allow View results to be altered by extensions

### DIFF
--- a/code/View.php
+++ b/code/View.php
@@ -102,6 +102,8 @@ class View extends DataObject implements PermissionProvider {
          $fields->addFieldToTab('Root.Main', new ViewResultsRetrieverTypeDropDownField());
       }
 
+      $this->extend('updateCMSFields', $fields);
+
       return $fields;
    }
 
@@ -235,6 +237,8 @@ class View extends DataObject implements PermissionProvider {
       // we will add pagination criteria to this below ... this query is for
       // "all" results so we get an accurate count, etc
       $results = $retriever->results();
+
+      $this->extend('modifyViewResults', $results);
 
       $totalItems = $results->count();
       $offset = $this->getResultsOffset();


### PR DESCRIPTION
The [default behavior of `DataObject` is to call `extend` in `getCMSFields`](http://api.silverstripe.org/3.1/source-class-DataObject.html#2080), this allows extensions to add extra fields to the Admin. This MR adds that behavior to `View`.

Additionally, this MR adds a hook (`modifyViewResults `) to modify the view results. This allows extensions to filter the list further or amend the returned data objects.